### PR TITLE
Fix Print_Ctrl buffer initialization and ownership

### DIFF
--- a/src/classes/Model_Control.cpp
+++ b/src/classes/Model_Control.cpp
@@ -353,6 +353,7 @@ void Print_Ctrl::Init(long st, int n, const char *s, int dt, double *x, int iFlu
         if(flag_IO[i]){ /* IO is TRUE*/
             PrintVar[k] = &x[i];
             icol[k] = (double) (i + 1);
+            buffer[k] = 0.0;
             k++;
         }
     }
@@ -365,10 +366,6 @@ void Print_Ctrl::Init(long st, int n, const char *s, int dt, double *x, int iFlu
 
 void Print_Ctrl::InitIJ(long st, int n, const char *s, int dt, double **x, int j, int iFlux, int *flag_IO){
     StartTime = st;
-    NumVar = n;
-    PrintVar = new double*[NumVar];
-    buffer = new double[NumVar];
-    icol    = new double[NumVar];
     strcpy(filename, s);
     if(dt == 0 ){
         myexit(ERRCONSIS);
@@ -385,11 +382,13 @@ void Print_Ctrl::InitIJ(long st, int n, const char *s, int dt, double **x, int j
     }
     buffer = new double[NumVar];
     PrintVar = new double*[NumVar];
+    icol    = new double[NumVar];
     int k = 0;
     for(int i = 0; i < n; i++){
         if(flag_IO[i]){ /* IO is TRUE*/
             PrintVar[k] = &(x[i][j]);
             icol[k] = (double) (i + 1);
+            buffer[k] = 0.0;
             k++;
         }
     }
@@ -401,10 +400,9 @@ void Print_Ctrl::InitIJ(long st, int n, const char *s, int dt, double **x, int j
     }
 }
 Print_Ctrl::~Print_Ctrl(){
-    if(NumVar > 0){
-        if(PrintVar != NULL ) delete[] PrintVar;
-        if(buffer != NULL ) delete[] buffer;
-    }
+    if(PrintVar != NULL ) delete[] PrintVar;
+    if(buffer != NULL ) delete[] buffer;
+    if(icol != NULL ) delete[] icol;
     close_file();
 }
 void Print_Ctrl::fun_printBINARY(double t, double dt){

--- a/src/classes/Model_Control.hpp
+++ b/src/classes/Model_Control.hpp
@@ -13,12 +13,12 @@
 
 class Print_Ctrl{
 private:
-    char    filename[MAXLEN];
-    char    header[1024];
+    char    filename[MAXLEN] = {};
+    char    header[1024] = {};
     int     Interval = NA_VALUE;
     int     NumVar = NA_VALUE;
     int     NumUpdate = 0;
-    double  *icol;
+    double  *icol = NULL;
     double  **PrintVar = NULL;
     double  *buffer = NULL;
     int     Binary = 1;
@@ -26,11 +26,13 @@ private:
     double  tau = 1440.;    // time unit in calculation. [min]
     FILE    *fid_bin = NULL;
     FILE    *fid_asc = NULL;
-    char    filea[MAXLEN];
-    char    fileb[MAXLEN];
-    long    StartTime;
+    char    filea[MAXLEN] = {};
+    char    fileb[MAXLEN] = {};
+    long    StartTime = 0;
 public:
     Print_Ctrl();
+    Print_Ctrl(const Print_Ctrl&) = delete;
+    Print_Ctrl& operator=(const Print_Ctrl&) = delete;
     ~Print_Ctrl();
     void    open_file(int a, int b);
     void    PrintData (double dt, double t);


### PR DESCRIPTION
## Summary

Fixes #7.

This PR fixes several `Print_Ctrl` lifecycle issues in `src/classes/Model_Control.*`:

- initialize `buffer[k]` in `Init(..., flag_IO)` before the first `+=` accumulation;
- initialize `buffer[k]` in `InitIJ(..., flag_IO)`;
- remove the first redundant allocation in `InitIJ(..., flag_IO)` before recalculating `NumVar`;
- allocate `icol` only after the final selected-column count is known;
- release `icol` in the destructor;
- release owned arrays regardless of `NumVar`, covering `new T[0]` cases;
- initialize character buffers and `StartTime` at construction;
- delete `Print_Ctrl` copy construction and assignment to prevent shallow-copy double-free / double-fclose risks.

## Notes

This PR intentionally does not change output column indexing, output intervals, binary layout, or `tau` behavior. The intended numeric change is limited to making the first output accumulation window deterministic instead of starting from uninitialized `double` values.

A separate issue was noticed during review: `dt_Qe_subx` / `dt_Qe_surfx` appear to be checked but not passed as the interval in `MD_initialize.cpp`. That is not changed here because it is separate from the `Print_Ctrl` lifecycle fix.

## Verification

- `git diff --check`
- `make shud`

`make shud` passes. Existing compiler warnings about `sprintf` buffer sizes and unchecked `fscanf` / `fgets` return values remain unchanged.
